### PR TITLE
chore(docker): add container build workflow and Dockerfile

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -188,7 +188,6 @@ jobs:
   hadolint:
     name: Hadolint
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - name: Checkout source code
@@ -221,3 +220,39 @@ jobs:
         run: |
           hadolint Dockerfile --failure-threshold error
 
+  container-build:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - hadolint
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 24
+          cache: maven
+
+      - name: Build JAR
+        run: mvn clean package -DskipTests
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.HARBOR_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_ROBOT_NAME }}
+          password: ${{ secrets.HARBOR_ROBOT_SECRET }}
+
+      - name: Build image
+        run: docker build -t ${{ secrets.HARBOR_REGISTRY_URL }}/bbb/service-b:${{ github.sha }} .
+
+      - name: Push image
+        run: docker push ${{ secrets.HARBOR_REGISTRY_URL }}/bbb/service-b:${{ github.sha }}
+
+      - name: Summary
+        run: |
+          echo " Image pushed to Harbor registry:"
+          echo "${{ secrets.HARBOR_REGISTRY_URL }}/bbb/service-b:${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazoncorretto:24-alpine-jdk
+WORKDIR /app
+COPY target/*.jar group-a-order.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/app/group-a-order.jar"]


### PR DESCRIPTION
Introduced a `container-build` job in the CI workflow for building and pushing Docker images to Harbor registry. Added a `Dockerfile` based on Amazon Corretto 24-alpine JDK for the service.